### PR TITLE
Removes broken link

### DIFF
--- a/doc/learnvim.txt
+++ b/doc/learnvim.txt
@@ -208,7 +208,6 @@ begin turning from vertical.  Here is a good place to start:
 
 There are also some really good Beginner Tutorials available online for Vim:
 
-* http://www.eng.hawaii.edu/Tutor/vi.html
 * http://blog.interlinked.org/tutorials/vim_tutorial.html
 * http://www.derekwyatt.org/vim/vim-tutorial-videos/vim-novice-tutorial-videos/
 


### PR DESCRIPTION
The link to http://www.eng.hawaii.edu/Tutor/vi.html does not seem to work. I've tried to find where it moved but I can't find it so I removed it instead.
