### PR TITLE
Add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
I installed LearnVim via git submodule and generated help tags with `:helptags ALL`, which creates `tags` file in `doc` directory, and git notifies that I've made differences to the repo. This fixes this problem.